### PR TITLE
Dependencias atualisadas

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,22 +27,22 @@
   },
   "homepage": "https://github.com/gmfc/pfnw5",
   "dependencies": {
-    "browser-serialport": "^2.0.3",
-    "simple-statistics": "^2.1.0"
+    "browser-serialport": "^2.1.0",
+    "simple-statistics": "^2.2.0"
   },
   "devDependencies": {
-    "browserify": "^13.1.0",
+    "browserify": "^14.1.0",
     "del": "^2.2.2",
     "gulp": "^3.9.1",
-    "gulp-jsdoc3": "^1.0.0",
+    "gulp-jsdoc3": "^1.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-uglify": "^2.0.0",
-    "gulp-watch": "^4.3.10",
-    "mocha": "^3.1.2",
-    "nw": "^0.19.0-rc1",
-    "nw-builder": "^3.1.2",
+    "gulp-uglify": "^2.0.1",
+    "gulp-watch": "^4.3.11",
+    "mocha": "^3.2.0",
+    "nw": "^0.20.2",
+    "nw-builder": "^3.2.0",
     "seedrandom": "^2.4.2",
-    "should": "^11.1.1",
+    "should": "^11.2.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   }


### PR DESCRIPTION
Critical:
 browserify      ^13.1.0  →  ^14.1.0 
 nw          ^0.19.0-rc1  →  ^0.20.2 

In range:
browser-serialport   ^2.0.3  →   ^2.1.0 
 simple-statistics    ^2.1.0  →   ^2.2.0 
 gulp-jsdoc3          ^1.0.0  →   ^1.0.1 
 gulp-uglify          ^2.0.0  →   ^2.0.1 
 gulp-watch          ^4.3.10  →  ^4.3.11 
 mocha                ^3.1.2  →   ^3.2.0 
 nw-builder           ^3.1.2  →   ^3.2.0 
 should              ^11.1.1  →  ^11.2.0